### PR TITLE
Recovery on worker failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Here is the instruction on how you can add support to other marketplaces.
 #### 1. Add a new marketplace config
 Use `src/lib/marketplaces/digitalEyes.ts` as example
 
-#### 2. Get write a test for the marketplace
+#### 2. Write a test for the marketplace
 Use `src/lib/marketplaces/digitalEyes.test.ts` as example
 
 #### 3. Add the new marketplace to the existing list 

--- a/src/workers/initWorkers.test.ts
+++ b/src/workers/initWorkers.test.ts
@@ -1,0 +1,46 @@
+import initWorkers from "./initWorkers";
+import { Worker } from "./types";
+
+jest.useFakeTimers();
+jest.spyOn(global, "setInterval");
+
+describe("initWorkers", () => {
+  async function sleep(ms: number) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+
+  test("run", () => {
+    const mockWorker: Worker = {
+      async execute() {},
+    };
+    jest.spyOn(mockWorker, "execute");
+
+    initWorkers([mockWorker]);
+
+    expect(mockWorker.execute).toHaveBeenCalledTimes(1);
+
+    jest.runOnlyPendingTimers();
+
+    expect(mockWorker.execute).toHaveBeenCalledTimes(2);
+  });
+
+  test("run after recover from error", () => {
+    const mockWorker: Worker = {
+      async execute() {
+        await sleep(20);
+        throw "error";
+      },
+    };
+    jest.spyOn(mockWorker, "execute");
+
+    initWorkers([mockWorker]);
+
+    expect(mockWorker.execute).toHaveBeenCalledTimes(1);
+
+    jest.runOnlyPendingTimers();
+
+    expect(mockWorker.execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/workers/initWorkers.ts
+++ b/src/workers/initWorkers.ts
@@ -1,24 +1,11 @@
-import Discord from "discord.js";
 import { Worker } from "./types";
-import notifyNFTSalesWorker from "./notifyNFTSalesWorker";
-import { Connection } from "@solana/web3.js";
-import { MutableConfig } from "../config";
 
 const defaultInterval = 1000 * 60; // 1 minutes
 
 export default function initWorkers(
-  discordClient: Discord.Client,
-  web3Conn: Connection,
-  config: MutableConfig,
+  workers: Worker[],
   interval: number = defaultInterval
 ) {
-  const workers: Worker[] = config.subscriptions.map((s) => {
-    return notifyNFTSalesWorker(discordClient, web3Conn, {
-      discordChannelId: s.discordChannelId,
-      mintAddress: s.mintAddress,
-    });
-  });
-
   if (!workers.length) {
     throw "Cannot init workers because no workers are configured: check env vars";
   }

--- a/src/workers/initWorkers.ts
+++ b/src/workers/initWorkers.ts
@@ -2,7 +2,7 @@ import { Worker } from "./types";
 
 const defaultInterval = 1000 * 60; // 1 minutes
 
-export default function initWorkers(
+export default async function initWorkers(
   workers: Worker[],
   interval: number = defaultInterval
 ) {
@@ -12,16 +12,18 @@ export default function initWorkers(
 
   console.log(`starting ${workers.length} worker(s)...`);
 
-  const runWorkers = () => {
-    try {
-      workers.forEach((w) => {
-        w.execute();
-      });
-    } catch (e) {
-      console.warn(e);
-    }
+  const runWorkers = async () => {
+    const promises = workers.map(async (w) => {
+      try {
+        return await w.execute();
+      } catch (e) {
+        console.warn(e);
+      }
+    });
+
+    return Promise.all(promises);
   };
 
-  runWorkers();
+  const _ = runWorkers();
   setInterval(runWorkers, interval);
 }

--- a/src/workers/types.ts
+++ b/src/workers/types.ts
@@ -1,3 +1,3 @@
 export interface Worker {
-  execute: () => void;
+  execute: () => Promise<void>;
 }


### PR DESCRIPTION
Currently, the server crashes if any worker fails, the catch and recovery code is not working. 
This PR fixes the recovery issues and allows the worker to continue to retry after the error.

This behavior is ideal because some RPC server is flakey, retrying could make the bot recover.