### PR TITLE
Fixed env legacy name

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,6 @@ SOLANA_RPC=https://explorer-api.mainnet-beta.solana.com/
 # Discord bot secret
 DISCORD_BOT_TOKEN=
 # The discord channel to notify
-DISCORD_CHANNEL_ID=
+SUBSCRIPTION_DISCORD_CHANNEL_ID=
 # Mint address to watch for sales
-MINT_ADDRESS=
+SUBSCRIPTION_MINT_ADDRESS=

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -19,6 +19,10 @@ export default function initWorkers(
     });
   });
 
+  if (!workers.length) {
+    throw "Cannot init workers because no workers are configured: check env vars";
+  }
+
   console.log(`starting ${workers.length} worker(s)...`);
 
   const runWorkers = () => {


### PR DESCRIPTION
We updated the env var name not long ago, but we forgot to update the example .env file.
This PR fixes it and added fail early error when spinning up the server. 
The bug should only affect development because the production env vars examples are correct.