### PR TITLE
Add ExchangeArt marketplaces support

### DIFF
--- a/src/lib/marketplaces/__fixtures__/exchangeArtSaleTx.ts
+++ b/src/lib/marketplaces/__fixtures__/exchangeArtSaleTx.ts
@@ -1,0 +1,289 @@
+import { ParsedConfirmedTransaction } from "@solana/web3.js";
+
+const saleTx: ParsedConfirmedTransaction = {
+  blockTime: 1636465965,
+  meta: {
+    err: null,
+    fee: 5000,
+    innerInstructions: [
+      {
+        index: 0,
+        instructions: [
+          {
+            parsed: {
+              info: {
+                destination: "6482e33zrerYfhKAjPR2ncMSrH2tbTy5LDjdhB5PXzxd",
+                lamports: 49750000,
+                source: "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+              },
+              type: "transfer",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                destination: "BhrcD75cVC4Dpuqat6QP9MwAEeyBf8GFZ74iMzv41jTm",
+                lamports: 0,
+                source: "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+              },
+              type: "transfer",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                destination: "4QJzmvKWpneEgHDa99QCb4hWtAhxA6qfFNtYWAb8Cw93",
+                lamports: 99500000,
+                source: "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+              },
+              type: "transfer",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                destination: "7ZvteCjTjt5HxYbmxyzo9xMavDEXkNLUG6r6pJJXijvj",
+                lamports: 99500000,
+                source: "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+              },
+              type: "transfer",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                destination: "7A6AV8pMznyt9eBXGbnkcgbuKhStz3vDQvWcRBoYWV5R",
+                lamports: 1741250000,
+                source: "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+              },
+              type: "transfer",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                amount: "1",
+                destination: "GzAM8LrsbDFHhmXkBsmUZ3aJad2G3y8XSJCMrfCXRqwb",
+                multisigAuthority:
+                  "BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2",
+                signers: ["BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2"],
+                source: "4Nh4j5A9ukweW3e14LaxmRGWKGM3ePrVjDamJfTc5HpQ",
+              },
+              type: "transfer",
+            },
+            program: "spl-token",
+            programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          },
+          {
+            parsed: {
+              info: {
+                account: "4Nh4j5A9ukweW3e14LaxmRGWKGM3ePrVjDamJfTc5HpQ",
+                destination: "7A6AV8pMznyt9eBXGbnkcgbuKhStz3vDQvWcRBoYWV5R",
+                multisigOwner: "BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2",
+                signers: ["BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2"],
+              },
+              type: "closeAccount",
+            },
+            program: "spl-token",
+            programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          },
+        ],
+      },
+    ],
+    logMessages: [
+      "Program AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn invoke [1]",
+      "Program log: Instruction: AcceptExchangeByTaker (amount: 1)",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+      "Program log: Instruction: Transfer",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3246 of 146259 compute units",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+      "Program log: Instruction: CloseAccount",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 2422 of 140048 compute units",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+      "Program AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn consumed 63945 of 200000 compute units",
+      "Program AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn success",
+    ],
+    postBalances: [
+      242200763, 2039280, 0, 1759795401, 0, 23534995018, 4572720, 149500000,
+      149495000, 1461600, 5616720, 1089991680, 1, 119000000, 1461600, 1141440,
+    ],
+    postTokenBalances: [
+      {
+        accountIndex: 1,
+        mint: "GSG2UXwfv5EE1Ad62bCc3pWcgJy5NRdFYof9JyyFZDMS",
+        uiTokenAmount: {
+          amount: "1",
+          decimals: 0,
+          uiAmount: 1.0,
+          uiAmountString: "1",
+        },
+      },
+    ],
+    preBalances: [
+      2232205763, 2039280, 2039280, 14877481, 1628640, 23485245018, 4572720,
+      50000000, 49995000, 1461600, 5616720, 1089991680, 1, 119000000, 1461600,
+      1141440,
+    ],
+    preTokenBalances: [
+      {
+        accountIndex: 1,
+        mint: "GSG2UXwfv5EE1Ad62bCc3pWcgJy5NRdFYof9JyyFZDMS",
+        uiTokenAmount: {
+          amount: "0",
+          decimals: 0,
+          uiAmount: null,
+          uiAmountString: "0",
+        },
+      },
+      {
+        accountIndex: 2,
+        mint: "GSG2UXwfv5EE1Ad62bCc3pWcgJy5NRdFYof9JyyFZDMS",
+        uiTokenAmount: {
+          amount: "1",
+          decimals: 0,
+          uiAmount: 1.0,
+          uiAmountString: "1",
+        },
+      },
+    ],
+    rewards: [],
+    status: { Ok: null },
+  },
+  slot: 106028506,
+  transaction: {
+    message: {
+      accountKeys: [
+        {
+          pubkey: "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+          signer: true,
+          writable: true,
+        },
+        {
+          pubkey: "GzAM8LrsbDFHhmXkBsmUZ3aJad2G3y8XSJCMrfCXRqwb",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "4Nh4j5A9ukweW3e14LaxmRGWKGM3ePrVjDamJfTc5HpQ",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "7A6AV8pMznyt9eBXGbnkcgbuKhStz3vDQvWcRBoYWV5R",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "8UcHhLq4euUGidninfLDzbBEq9jnQRsMF9hHvPtW4dC4",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "6482e33zrerYfhKAjPR2ncMSrH2tbTy5LDjdhB5PXzxd",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "BhrcD75cVC4Dpuqat6QP9MwAEeyBf8GFZ74iMzv41jTm",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "4QJzmvKWpneEgHDa99QCb4hWtAhxA6qfFNtYWAb8Cw93",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "7ZvteCjTjt5HxYbmxyzo9xMavDEXkNLUG6r6pJJXijvj",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "GSG2UXwfv5EE1Ad62bCc3pWcgJy5NRdFYof9JyyFZDMS",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "FLUgjuKHWySQ5gnQxmqnvoeydHcLY8VdfjNbFrpvYLNR",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "11111111111111111111111111111111",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "9jd5tCY3JhjfSYSpgRzsgpoF5V52rNXYm4eRMfXeqUwR",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn",
+          signer: false,
+          writable: false,
+        },
+      ],
+      instructions: [
+        {
+          accounts: [
+            "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+            "GzAM8LrsbDFHhmXkBsmUZ3aJad2G3y8XSJCMrfCXRqwb",
+            "4Nh4j5A9ukweW3e14LaxmRGWKGM3ePrVjDamJfTc5HpQ",
+            "7A6AV8pMznyt9eBXGbnkcgbuKhStz3vDQvWcRBoYWV5R",
+            "8UcHhLq4euUGidninfLDzbBEq9jnQRsMF9hHvPtW4dC4",
+            "6482e33zrerYfhKAjPR2ncMSrH2tbTy5LDjdhB5PXzxd",
+            "GSG2UXwfv5EE1Ad62bCc3pWcgJy5NRdFYof9JyyFZDMS",
+            "FLUgjuKHWySQ5gnQxmqnvoeydHcLY8VdfjNbFrpvYLNR",
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "11111111111111111111111111111111",
+            "BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2",
+            "9jd5tCY3JhjfSYSpgRzsgpoF5V52rNXYm4eRMfXeqUwR",
+            "BhrcD75cVC4Dpuqat6QP9MwAEeyBf8GFZ74iMzv41jTm",
+            "4QJzmvKWpneEgHDa99QCb4hWtAhxA6qfFNtYWAb8Cw93",
+            "7ZvteCjTjt5HxYbmxyzo9xMavDEXkNLUG6r6pJJXijvj",
+          ],
+          data: "jzDsaTSmGkw",
+          programId: "AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn",
+        },
+      ],
+      recentBlockhash: "Cj3zXV6hkKDMRmAkgdfURo3acZ5h2W28LbariB3ZrFJh",
+    },
+    signatures: [
+      "4WniSeFvZHsnZEDueeWhP18dUC9bGwZjoQ19RQq14796GCdb7WVRsTjK8AZCLLhL136p4J96minzfZcKVjY3fNAY",
+    ],
+  },
+};
+
+export default saleTx;

--- a/src/lib/marketplaces/__fixtures__/exchangeArtSaleTxV2.ts
+++ b/src/lib/marketplaces/__fixtures__/exchangeArtSaleTxV2.ts
@@ -1,0 +1,351 @@
+import { ParsedConfirmedTransaction } from "@solana/web3.js";
+
+const saleTx: ParsedConfirmedTransaction = {
+  blockTime: 1637139756,
+  meta: {
+    err: null,
+    fee: 5000,
+    innerInstructions: [
+      {
+        index: 0,
+        instructions: [
+          {
+            parsed: {
+              info: {
+                destination: "6oTEszeAVQwvFgUkcitipR865qQUAy3UQ5ys5rfNDXC6",
+                lamports: 2039280,
+                source: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+              },
+              type: "transfer",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                account: "6oTEszeAVQwvFgUkcitipR865qQUAy3UQ5ys5rfNDXC6",
+                space: 165,
+              },
+              type: "allocate",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                account: "6oTEszeAVQwvFgUkcitipR865qQUAy3UQ5ys5rfNDXC6",
+                owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              },
+              type: "assign",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                account: "6oTEszeAVQwvFgUkcitipR865qQUAy3UQ5ys5rfNDXC6",
+                mint: "BtoorpGmtSydBtUfCaiHAEFPnE6Q4QKopTKrix6Ftcn2",
+                owner: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+                rentSysvar: "SysvarRent111111111111111111111111111111111",
+              },
+              type: "initializeAccount",
+            },
+            program: "spl-token",
+            programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          },
+        ],
+      },
+      {
+        index: 1,
+        instructions: [
+          {
+            parsed: {
+              info: {
+                destination: "6482e33zrerYfhKAjPR2ncMSrH2tbTy5LDjdhB5PXzxd",
+                lamports: 5000000,
+                source: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+              },
+              type: "transfer",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                destination: "2DXWoqh6dCp8VFWwuPszWXcWAnegaEMyT4UVgRMJJzQn",
+                lamports: 0,
+                source: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+              },
+              type: "transfer",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                destination: "8pJyixptCqPPLSkT9qqjMmJjAELdP8YiGsL1ihNmSsaE",
+                lamports: 100000000,
+                source: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+              },
+              type: "transfer",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                destination: "3Z6T94rMaTKjfdQb9ShunvMJ6C9LqDqEkfKBBeGArpzp",
+                lamports: 95000000,
+                source: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+              },
+              type: "transfer",
+            },
+            program: "system",
+            programId: "11111111111111111111111111111111",
+          },
+          {
+            parsed: {
+              info: {
+                amount: "1",
+                destination: "6oTEszeAVQwvFgUkcitipR865qQUAy3UQ5ys5rfNDXC6",
+                multisigAuthority:
+                  "BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2",
+                signers: ["BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2"],
+                source: "HukHCJmGZLG6BEr8MjjacEoeJzjiMuwX4Y5Q5Yyvm1Lo",
+              },
+              type: "transfer",
+            },
+            program: "spl-token",
+            programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          },
+          {
+            parsed: {
+              info: {
+                account: "HukHCJmGZLG6BEr8MjjacEoeJzjiMuwX4Y5Q5Yyvm1Lo",
+                destination: "3Z6T94rMaTKjfdQb9ShunvMJ6C9LqDqEkfKBBeGArpzp",
+                multisigOwner: "BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2",
+                signers: ["BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2"],
+              },
+              type: "closeAccount",
+            },
+            program: "spl-token",
+            programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          },
+        ],
+      },
+    ],
+    logMessages: [
+      "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]",
+      "Program log: Transfer 2039280 lamports to the associated token account",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program log: Allocate space for the associated token account",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program log: Assign the associated token account to the SPL Token program",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program log: Initialize the associated token account",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+      "Program log: Instruction: InitializeAccount",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3449 of 179574 compute units",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+      "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 24524 of 200000 compute units",
+      "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success",
+      "Program AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn invoke [1]",
+      "Program log: Instruction: AcceptExchangeByTaker (amount: 1)",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program log: final seller fee basis points after PHBT: 5000.0",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program 11111111111111111111111111111111 invoke [2]",
+      "Program 11111111111111111111111111111111 success",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+      "Program log: Instruction: Transfer",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3246 of 144566 compute units",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+      "Program log: Instruction: CloseAccount",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 2422 of 138355 compute units",
+      "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+      "Program AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn consumed 65510 of 200000 compute units",
+      "Program AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn success",
+    ],
+    postBalances: [
+      3583436090, 2039280, 0, 178325906, 0, 92565366518, 4572720, 16484238885,
+      1461600, 1, 1089991680, 1009200, 5616720, 166000000, 898174080, 1141440,
+    ],
+    postTokenBalances: [
+      {
+        accountIndex: 1,
+        mint: "BtoorpGmtSydBtUfCaiHAEFPnE6Q4QKopTKrix6Ftcn2",
+        owner: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+        uiTokenAmount: {
+          amount: "1",
+          decimals: 0,
+          uiAmount: 1.0,
+          uiAmountString: "1",
+        },
+      },
+    ],
+    preBalances: [
+      3785480370, 0, 2039280, 79657986, 1628640, 92560366518, 4572720,
+      16384238885, 1461600, 1, 1089991680, 1009200, 5616720, 166000000,
+      898174080, 1141440,
+    ],
+    preTokenBalances: [
+      {
+        accountIndex: 2,
+        mint: "BtoorpGmtSydBtUfCaiHAEFPnE6Q4QKopTKrix6Ftcn2",
+        owner: "BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2",
+        uiTokenAmount: {
+          amount: "1",
+          decimals: 0,
+          uiAmount: 1.0,
+          uiAmountString: "1",
+        },
+      },
+    ],
+    rewards: [],
+    status: { Ok: null },
+  },
+  slot: 107304222,
+  transaction: {
+    message: {
+      accountKeys: [
+        {
+          pubkey: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+          signer: true,
+          writable: true,
+        },
+        {
+          pubkey: "6oTEszeAVQwvFgUkcitipR865qQUAy3UQ5ys5rfNDXC6",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "HukHCJmGZLG6BEr8MjjacEoeJzjiMuwX4Y5Q5Yyvm1Lo",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "3Z6T94rMaTKjfdQb9ShunvMJ6C9LqDqEkfKBBeGArpzp",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "BjEdwXRGZh6NLk99P5utngc5Wed7UHYgxHBSQStq4o54",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "6482e33zrerYfhKAjPR2ncMSrH2tbTy5LDjdhB5PXzxd",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "2DXWoqh6dCp8VFWwuPszWXcWAnegaEMyT4UVgRMJJzQn",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "8pJyixptCqPPLSkT9qqjMmJjAELdP8YiGsL1ihNmSsaE",
+          signer: false,
+          writable: true,
+        },
+        {
+          pubkey: "BtoorpGmtSydBtUfCaiHAEFPnE6Q4QKopTKrix6Ftcn2",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "11111111111111111111111111111111",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "SysvarRent111111111111111111111111111111111",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "CiFhuzidkjaxprBVPAENEpoRJsGkcxXnv2SNLPktYy7B",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          signer: false,
+          writable: false,
+        },
+        {
+          pubkey: "AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn",
+          signer: false,
+          writable: false,
+        },
+      ],
+      instructions: [
+        {
+          parsed: {
+            info: {
+              account: "6oTEszeAVQwvFgUkcitipR865qQUAy3UQ5ys5rfNDXC6",
+              mint: "BtoorpGmtSydBtUfCaiHAEFPnE6Q4QKopTKrix6Ftcn2",
+              rentSysvar: "SysvarRent111111111111111111111111111111111",
+              source: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+              systemProgram: "11111111111111111111111111111111",
+              tokenProgram: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              wallet: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+            },
+            type: "create",
+          },
+          program: "spl-associated-token-account",
+          programId: "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+        },
+        {
+          accounts: [
+            "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+            "6oTEszeAVQwvFgUkcitipR865qQUAy3UQ5ys5rfNDXC6",
+            "HukHCJmGZLG6BEr8MjjacEoeJzjiMuwX4Y5Q5Yyvm1Lo",
+            "3Z6T94rMaTKjfdQb9ShunvMJ6C9LqDqEkfKBBeGArpzp",
+            "BjEdwXRGZh6NLk99P5utngc5Wed7UHYgxHBSQStq4o54",
+            "6482e33zrerYfhKAjPR2ncMSrH2tbTy5LDjdhB5PXzxd",
+            "BtoorpGmtSydBtUfCaiHAEFPnE6Q4QKopTKrix6Ftcn2",
+            "CiFhuzidkjaxprBVPAENEpoRJsGkcxXnv2SNLPktYy7B",
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "11111111111111111111111111111111",
+            "BjaNzGdwRcFYeQGfuLYsc1BbaNRG1yxyWs1hZuGRT8J2",
+            "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+            "2DXWoqh6dCp8VFWwuPszWXcWAnegaEMyT4UVgRMJJzQn",
+            "8pJyixptCqPPLSkT9qqjMmJjAELdP8YiGsL1ihNmSsaE",
+          ],
+          data: "jzDsaTSmGkw",
+          programId: "AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn",
+        },
+      ],
+      recentBlockhash: "784RVPH2bwcPFdAjA3ozdeYFTgWTkAQtD5q6zcsPikty",
+    },
+    signatures: [
+      "496U5Ric72tCEwDVekapUVqCGrHEeSTpA9wsn88R65nT8hZbuEZS5sjgn5iT4mnmSKbSNcTf4Q7Bdu2hyjWcqaAD",
+    ],
+  },
+};
+export default saleTx;

--- a/src/lib/marketplaces/exchangeArt.test.ts
+++ b/src/lib/marketplaces/exchangeArt.test.ts
@@ -1,0 +1,105 @@
+import exchangeArt from "./exchangeArt";
+import exchangeArtSaleTx from "./__fixtures__/exchangeArtSaleTx";
+import exchangeArtSaleTxV2 from "./__fixtures__/exchangeArtSaleTxV2";
+
+describe("exchangeArt", () => {
+  test("itemUrl", () => {
+    expect(exchangeArt.itemURL("xxx1")).toEqual(
+      "https://exchange.art/single/xxx1"
+    );
+  });
+
+  describe("parseNFTSale", () => {
+    test("sale transaction should return NFTSale", () => {
+      const sale = exchangeArt.parseNFTSale(exchangeArtSaleTx);
+      expect(sale.transaction).toEqual(
+        "4WniSeFvZHsnZEDueeWhP18dUC9bGwZjoQ19RQq14796GCdb7WVRsTjK8AZCLLhL136p4J96minzfZcKVjY3fNAY"
+      );
+      expect(sale.token).toEqual(
+        "GSG2UXwfv5EE1Ad62bCc3pWcgJy5NRdFYof9JyyFZDMS"
+      );
+      expect(sale.soldAt).toEqual(new Date(1636465965 * 1000));
+      expect(sale.marketplace).toEqual(exchangeArt);
+      expect(sale.getPriceInLamport()).toEqual(1990000000);
+      expect(sale.getPriceInSOL()).toEqual(1.99);
+
+      const expectedTransfers = [
+        {
+          to: "6482e33zrerYfhKAjPR2ncMSrH2tbTy5LDjdhB5PXzxd",
+          revenue: { amount: 49750000, symbol: "lamport" },
+          from: "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+        },
+        {
+          to: "4QJzmvKWpneEgHDa99QCb4hWtAhxA6qfFNtYWAb8Cw93",
+          revenue: { amount: 99500000, symbol: "lamport" },
+          from: "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+        },
+        {
+          to: "7ZvteCjTjt5HxYbmxyzo9xMavDEXkNLUG6r6pJJXijvj",
+          revenue: { amount: 99500000, symbol: "lamport" },
+          from: "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+        },
+        {
+          to: "7A6AV8pMznyt9eBXGbnkcgbuKhStz3vDQvWcRBoYWV5R",
+          revenue: { amount: 1741250000, symbol: "lamport" },
+          from: "8WX1T8ofK91YxcPHp9t1wnQanHfcu4Nzy3fwQqMNGecJ",
+        },
+      ];
+      expect(sale.transfers.length).toEqual(expectedTransfers.length);
+      expectedTransfers.forEach((expectedTransfer, index) => {
+        const transfer = sale.transfers[index];
+        expect(transfer.from).toEqual(expectedTransfer.from);
+        expect(transfer.to).toEqual(expectedTransfer.to);
+        expect(transfer.revenue).toEqual(expectedTransfer.revenue);
+      });
+    });
+    test("sale transaction v2 should return NFTSale", () => {
+      const sale = exchangeArt.parseNFTSale(exchangeArtSaleTxV2);
+      expect(sale.marketplace).toEqual(exchangeArt);
+      expect(sale.getPriceInLamport()).toEqual(200000000);
+      expect(sale.getPriceInSOL()).toEqual(0.2);
+
+      const expectedTransfers = [
+        {
+          to: "6482e33zrerYfhKAjPR2ncMSrH2tbTy5LDjdhB5PXzxd",
+          revenue: { amount: 5000000, symbol: "lamport" },
+          from: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+        },
+        {
+          to: "8pJyixptCqPPLSkT9qqjMmJjAELdP8YiGsL1ihNmSsaE",
+          revenue: { amount: 100000000, symbol: "lamport" },
+          from: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+        },
+        {
+          to: "3Z6T94rMaTKjfdQb9ShunvMJ6C9LqDqEkfKBBeGArpzp",
+          revenue: { amount: 95000000, symbol: "lamport" },
+          from: "FR4xWcvhxA2dLTDda5cmD1zUxz9gnzrVhhLq4owcAzt3",
+        },
+      ];
+      expect(sale.transfers.length).toEqual(expectedTransfers.length);
+      expectedTransfers.forEach((expectedTransfer, index) => {
+        const transfer = sale.transfers[index];
+        expect(transfer.from).toEqual(expectedTransfer.from);
+        expect(transfer.to).toEqual(expectedTransfer.to);
+        expect(transfer.revenue).toEqual(expectedTransfer.revenue);
+      });
+    });
+    test("non-sale transaction should return null", () => {
+      const invalidSaleTx = {
+        ...exchangeArtSaleTx,
+        meta: {
+          ...exchangeArtSaleTx.meta,
+          preTokenBalances: [],
+        },
+      };
+      expect(exchangeArt.parseNFTSale(invalidSaleTx)).toBe(null);
+    });
+    test("non exchange art transaction", () => {
+      const invalidSaleTx = {
+        ...exchangeArtSaleTx,
+      };
+      invalidSaleTx.meta.logMessages = ["Program xxx invoke [1]"];
+      expect(exchangeArt.parseNFTSale(invalidSaleTx)).toBe(null);
+    });
+  });
+});

--- a/src/lib/marketplaces/exchangeArt.ts
+++ b/src/lib/marketplaces/exchangeArt.ts
@@ -1,0 +1,13 @@
+import { Marketplace, NFTSale } from "./types";
+import { parseNFTSaleOnTx } from "./helper";
+
+const exchangeArt: Marketplace = {
+  name: "Exchange Art",
+  programId: "AmK5g2XcyptVLCFESBCJqoSfwV3znGoVYQnqEnaAZKWn",
+  itemURL: (token: String) => `https://exchange.art/single/${token}`,
+  parseNFTSale(txResp): NFTSale | null {
+    return parseNFTSaleOnTx(txResp, this);
+  },
+};
+
+export default exchangeArt;

--- a/src/lib/marketplaces/helper.test.ts
+++ b/src/lib/marketplaces/helper.test.ts
@@ -1,6 +1,16 @@
 import { parseNFTSaleOnTx } from "./helper";
 import solanartSalesTxWithFloatingLamport from "./__fixtures__/solanartSalesTxWithFloatingLamport";
 import solanart from "./solanart";
+import magicEdenSaleTx from "./__fixtures__/magicEdenSaleTx";
+import digitalEyeSaleTx from "./__fixtures__/digitalEyesSaleTx";
+import solanartSaleTx from "./__fixtures__/solanartSaleTx";
+import alphaArtSaleTx from "./__fixtures__/alphaArtSaleTx";
+import exchangeArtSaleTx from "./__fixtures__/exchangeArtSaleTx";
+import exchangeArtSaleTxV2 from "./__fixtures__/exchangeArtSaleTxV2";
+import magicEden from "./magicEden";
+import digitalEyes from "./digitalEyes";
+import alphaArt from "./alphaArt";
+import exchangeArt from "./exchangeArt";
 
 describe("helper", () => {
   describe("parseNFTSaleOnTx", () => {
@@ -12,6 +22,120 @@ describe("helper", () => {
       );
       expect(nftSale).toBeTruthy();
       expect(nftSale.getPriceInSOL()).toEqual(0.06);
+    });
+
+    test("should parse nft sales", () => {
+      const sale = parseNFTSaleOnTx(magicEdenSaleTx, magicEden);
+      expect(sale.transaction).toEqual(
+        "626EgwuS6dbUKrkZujQCFjHiRsz92ALR5gNAEg2eMpZzEo88Cci6HifpDFcvgYR8j88nXUq1nRUA7UDRdvB7Y6WD"
+      );
+      expect(sale.token).toEqual(
+        "8pwYVy61QiSTJGPc8yYfkVPLBBr8r17WkpUFRhNK6cjK"
+      );
+      expect(sale.soldAt).toEqual(new Date(1635141315000));
+      expect(sale.marketplace).toEqual(magicEden);
+      expect(sale.getPriceInLamport()).toEqual(3720000000);
+      expect(sale.getPriceInSOL()).toEqual(3.72);
+
+      const expectedTransfers = [
+        {
+          to: "2NZukH2TXpcuZP4htiuT8CFxcaQSWzkkR6kepSWnZ24Q",
+          from: "U7ZkJtaAwvBHt9Tw5BK8sdp2wLrEe7p1g3kFxB9WJCu",
+          revenue: {
+            amount: 74400000,
+            symbol: "lamport",
+          },
+        },
+        {
+          to: "4eQwMqAA4c2VUD51rqfAke7kqeFLAxcxSB67rtFjDyZA",
+          from: "U7ZkJtaAwvBHt9Tw5BK8sdp2wLrEe7p1g3kFxB9WJCu",
+          revenue: {
+            amount: 74400000,
+            symbol: "lamport",
+          },
+        },
+        {
+          to: "Dz9kwoBVVzF11cHeKotQpA7t4aeCQsgRpVw4dg8zkntg",
+          from: "U7ZkJtaAwvBHt9Tw5BK8sdp2wLrEe7p1g3kFxB9WJCu",
+          revenue: {
+            amount: 74400000,
+            symbol: "lamport",
+          },
+        },
+        {
+          to: "4xHEEswq2T2E5uNoa1uw34RNKzPerayBHxX3P4SaR7cD",
+          from: "U7ZkJtaAwvBHt9Tw5BK8sdp2wLrEe7p1g3kFxB9WJCu",
+          revenue: {
+            amount: 74400000,
+            symbol: "lamport",
+          },
+        },
+        {
+          to: "33CJriD17bUScYW7eKFjM6BPfkFWPerHfdpvtw3a8JdN",
+          from: "U7ZkJtaAwvBHt9Tw5BK8sdp2wLrEe7p1g3kFxB9WJCu",
+          revenue: {
+            amount: 74400000,
+            symbol: "lamport",
+          },
+        },
+        {
+          to: "HWZybKNqMa93EmHK2ESL2v1XShcnt4ma4nFf14497jNS",
+          from: "U7ZkJtaAwvBHt9Tw5BK8sdp2wLrEe7p1g3kFxB9WJCu",
+          revenue: {
+            amount: 74400000,
+            symbol: "lamport",
+          },
+        },
+        {
+          to: "HihC794BdNCetkizxdFjVD2KiKWirGYbm2ojvRYXQd6H",
+          from: "U7ZkJtaAwvBHt9Tw5BK8sdp2wLrEe7p1g3kFxB9WJCu",
+          revenue: {
+            amount: 3273600000,
+            symbol: "lamport",
+          },
+        },
+      ];
+      expect(sale.transfers.length).toEqual(expectedTransfers.length);
+      expectedTransfers.forEach((expectedTransfer, index) => {
+        const transfer = sale.transfers[index];
+        expect(transfer.from).toEqual(expectedTransfer.from);
+        expect(transfer.to).toEqual(expectedTransfer.to);
+        expect(transfer.revenue).toEqual(expectedTransfer.revenue);
+      });
+    });
+
+    test("should parse all marketplace purchases", () => {
+      const invalidTx = {
+        ...magicEdenSaleTx,
+        meta: {
+          ...magicEdenSaleTx.meta,
+          preTokenBalances: [],
+        },
+      };
+
+      [
+        { tx: magicEdenSaleTx, martketplace: magicEden, shouldParsed: true },
+        { tx: invalidTx, martketplace: magicEden, shouldParsed: false },
+        { tx: magicEdenSaleTx, martketplace: digitalEyes, shouldParsed: false },
+        { tx: digitalEyeSaleTx, martketplace: digitalEyes, shouldParsed: true },
+        { tx: digitalEyeSaleTx, martketplace: solanart, shouldParsed: false },
+        { tx: solanartSaleTx, martketplace: solanart, shouldParsed: true },
+        { tx: solanartSaleTx, martketplace: digitalEyes, shouldParsed: false },
+        { tx: alphaArtSaleTx, martketplace: alphaArt, shouldParsed: true },
+        {
+          tx: exchangeArtSaleTx,
+          martketplace: exchangeArt,
+          shouldParsed: true,
+        },
+        {
+          tx: exchangeArtSaleTxV2,
+          martketplace: exchangeArt,
+          shouldParsed: true,
+        },
+      ].forEach((testCase) => {
+        const nftSale = parseNFTSaleOnTx(testCase.tx, testCase.martketplace);
+        expect(Boolean(nftSale)).toEqual(testCase.shouldParsed);
+      });
     });
   });
 });

--- a/src/lib/marketplaces/helper.ts
+++ b/src/lib/marketplaces/helper.ts
@@ -33,7 +33,7 @@ export function getTransfersFromInnerInstructions(
 export function parseNFTSaleOnTx(
   txResp: ParsedConfirmedTransaction,
   marketplace: Marketplace,
-  transferInstructionIndex: number = 0
+  transferInstructionIndex?: number
 ): NFTSale | null {
   if (!txResp.meta?.logMessages) {
     return null;
@@ -52,11 +52,17 @@ export function parseNFTSaleOnTx(
   if (!transactionExecByMarketplaceProgram) {
     return null;
   }
+
   const { innerInstructions } = txResp.meta;
-  if (
-    !innerInstructions ||
-    innerInstructions.length < transferInstructionIndex + 1
-  ) {
+  if (!innerInstructions) {
+    return null;
+  }
+
+  // Use the last index of it's not set
+  if (typeof transferInstructionIndex == "undefined") {
+    transferInstructionIndex = innerInstructions.length - 1;
+  }
+  if (innerInstructions.length < transferInstructionIndex + 1) {
     return null;
   }
   if (!txResp?.blockTime) {

--- a/src/lib/marketplaces/marketplaces.ts
+++ b/src/lib/marketplaces/marketplaces.ts
@@ -3,6 +3,7 @@ import magicEden from "./magicEden";
 import digitalEyes from "./digitalEyes";
 import solanart from "./solanart";
 import alphaArt from "./alphaArt";
+import exchangeArt from "./exchangeArt";
 
 /**
  * These are the list of marketplaces that we check for notifications
@@ -12,6 +13,7 @@ const marketplaces: Marketplace[] = [
   digitalEyes,
   solanart,
   alphaArt,
+  exchangeArt,
 ];
 
 export default marketplaces;

--- a/src/lib/marketplaces/parseNFTSaleForAllMarkets.test.ts
+++ b/src/lib/marketplaces/parseNFTSaleForAllMarkets.test.ts
@@ -3,15 +3,20 @@ import parseNFTSaleForAllMarkets from "./parseNFTSaleForAllMarkets";
 import alphaArtSaleTx from "./__fixtures__/alphaArtSaleTx";
 import solanartSaleTx from "./__fixtures__/solanartSaleTx";
 import digitalEyeSaleTx from "./__fixtures__/digitalEyesSaleTx";
+import exchangeArtSaleTx from "./__fixtures__/exchangeArtSaleTx";
 
 describe("parseNFTSale", () => {
   test("sale transaction should return NFTSale", () => {
-    [magicEdenSaleTx, digitalEyeSaleTx, solanartSaleTx, alphaArtSaleTx].forEach(
-      (tx) => {
-        const sale = parseNFTSaleForAllMarkets(tx);
-        expect(sale?.transaction).toEqual(tx.transaction.signatures[0]);
-      }
-    );
+    [
+      magicEdenSaleTx,
+      digitalEyeSaleTx,
+      solanartSaleTx,
+      alphaArtSaleTx,
+      exchangeArtSaleTx,
+    ].forEach((tx) => {
+      const sale = parseNFTSaleForAllMarkets(tx);
+      expect(sale?.transaction).toEqual(tx.transaction.signatures[0]);
+    });
   });
 
   test("non-sale transaction should return null", () => {

--- a/src/lib/solana/NFTData.ts
+++ b/src/lib/solana/NFTData.ts
@@ -10,7 +10,14 @@ export default interface NFTData {
 export async function fetchNFTData(
   web3Conn: Connection,
   token: string
-): Promise<NFTData | null> {
-  const metadata = await Metadata.load(web3Conn, await Metadata.getPDA(token));
-  return (await axios.get<NFTData>(metadata.data.data.uri)).data;
+): Promise<NFTData | undefined> {
+  try {
+    const metadata = await Metadata.load(
+      web3Conn,
+      await Metadata.getPDA(token)
+    );
+    return (await axios.get<NFTData>(metadata.data.data.uri)).data;
+  } catch (e) {
+    console.error("fetch NFT data failed", e);
+  }
 }


### PR DESCRIPTION
It looks like there are two variations of purchase transactions for ExchangeArt marketplace: 
One with the transfers in the 1st item of the instruction array and the other one in the 2nd item. 

From analysing existing transactions, I have found the pattern that all SOL transfers are in the last item of the instructions. 
Testing this assumption seems to hold up, not just ExchangeArt but for other marketplaces too, shown in the tests here:
https://github.com/milktoastlab/SolanaNFTBot/compare/add-more-marketplaces-support?expand=1#diff-193d13a33dcc5c94326717c36ff249af2328a2768d02fe0384c0322d3d7f98fa

After this change is shipped and if no issues reported, we can simplify the tests for all marketplaces moving forward. It should reduce the friction of adding support for new Marketplaces.

<img width="500" alt="Screen Shot 2021-11-18 at 10 28 31 pm" src="https://user-images.githubusercontent.com/90617759/142407240-7677a0fc-73a4-47ab-b179-7970b7cd018c.png">
