### PR TITLE
Incremental improvements

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,8 @@ import { getStatus } from "lib/discord/notifyDiscordSale";
 import { loadConfig } from "config";
 import { Worker } from "workers/types";
 import notifyNFTSalesWorker from "workers/notifyNFTSalesWorker";
+import { parseNFTSale } from "./lib/marketplaces";
+import { ParsedConfirmedTransaction } from "@solana/web3.js";
 
 const port = process.env.PORT || 4000;
 
@@ -17,6 +19,8 @@ const port = process.env.PORT || 4000;
       throw result.error;
     }
     const config = loadConfig();
+
+    const web3Conn = newConnection();
 
     const server = express();
     server.get("/", (req, res) => {
@@ -36,6 +40,35 @@ const port = process.env.PORT || 4000;
       `);
     });
 
+    server.get("/parse-sale-tx", async (req, res) => {
+      const signature = (req.query["signature"] as string) || "";
+      if (!signature) {
+        res.send(`no signature in query param`);
+        return;
+      }
+
+      let tx: ParsedConfirmedTransaction | null = null;
+      try {
+        tx = await web3Conn.getParsedConfirmedTransaction(signature);
+      } catch (e) {
+        console.log(e);
+        res.send(`Get transaction failed, check logs for error.`);
+        return;
+      }
+      if (!tx) {
+        res.send(`No transaction found for ${signature}`);
+        return;
+      }
+      const nftSale = parseNFTSale(tx);
+      if (!nftSale) {
+        res.send(
+          `No NFT Sale detected for tx: ${signature}\n${JSON.stringify(tx)}`
+        );
+        return;
+      }
+      res.send(`NFT Sales parsed: \n${JSON.stringify(nftSale)}`);
+    });
+
     server.listen(port, (err?: any) => {
       if (err) throw err;
       console.log(
@@ -44,7 +77,6 @@ const port = process.env.PORT || 4000;
     });
 
     const discordClient = await initDiscordClient();
-    const web3Conn = newConnection();
 
     const workers: Worker[] = config.subscriptions.map((s) => {
       return notifyNFTSalesWorker(discordClient, web3Conn, {


### PR DESCRIPTION
## 1. Optimize the call to fetch signatures 

Before this commit the worker would fetch the last 50 signatures
every time, even include the one it has already looked at.

This commit makes it smarter, only fetch the new signatures to eliminate
n+1 calls in getParsedConfirmTransaction call.
The improvement should reduce cost for paid rpc nodes and server usage
overall.

As a side effect of this improvement, we're now reading the transactions from earliest to latest which allow us to simplify the logic when traversing through the transactions.

## 2. Add /parse-sale-tx endpoint
Having this route should allow us to debug/test transactions in production