### PR TITLE
Add auth key and fix port in env

### DIFF
--- a/src/lib/solana/connection.ts
+++ b/src/lib/solana/connection.ts
@@ -1,12 +1,17 @@
 import {
   ConfirmedSignaturesForAddress2Options,
   Connection,
+  ConnectionConfig,
   ParsedConfirmedTransaction,
   PublicKey,
 } from "@solana/web3.js";
 
 export function newConnection(): Connection {
-  return new Connection(process.env.SOLANA_RPC || "");
+  const config: ConnectionConfig = {};
+  if (process.env.SOLANA_RPC_KEY_SECRET) {
+    config.httpHeaders = { Authorization: process.env.SOLANA_RPC_KEY_SECRET };
+  }
+  return new Connection(process.env.SOLANA_RPC || "", config);
 }
 
 interface Opt extends ConfirmedSignaturesForAddress2Options {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,8 +15,6 @@ import { ParsedConfirmedTransaction } from "@solana/web3.js";
 import initTwitterClient from "lib/twitter";
 import notifyTwitter from "lib/twitter/notifyTwitter";
 
-const port = process.env.PORT || 4000;
-
 (async () => {
   try {
     const result = dotenv.config();
@@ -24,6 +22,7 @@ const port = process.env.PORT || 4000;
       throw result.error;
     }
     const config = loadConfig();
+    const port = process.env.PORT || 4000;
 
     const web3Conn = newConnection();
     const discordClient = await initDiscordClient();


### PR DESCRIPTION
1. Add a config variable `SOLANA_RPC_KEY_SECRET` to setup an Authorization key (if one is using Figment as an endpoint provider for instance).
2. Fix the `PORT` env variable: it was ignored because read prior to calling `dotenv.config`