### PR TITLE
Add commitment for getConfirmedSignaturesForAddress2

### DIFF
--- a/src/lib/solana/connection.ts
+++ b/src/lib/solana/connection.ts
@@ -29,7 +29,8 @@ export async function fetchWeb3Transactions(
       limit: opt?.limit,
       before: opt?.before,
       until: opt?.until,
-    }
+    },
+    'finalized'
   );
 
   if (signatures) {


### PR DESCRIPTION
We received a problem today (Feb 14) that a Discord notification was being sent multiple times for the same sale. The problem could be that the block is not checked if it is finished or not.

So I simply added the option "commitment" to the function getConfirmedSignaturesForAddress2 (connection.ts) to take into account only finalized transactions. This will avoid duplicate notifications