### PR TITLE
🐛 add an optional chain to instructions filter

### DIFF
--- a/src/lib/marketplaces/helper.ts
+++ b/src/lib/marketplaces/helper.ts
@@ -25,7 +25,7 @@ export function getTransfersFromInnerInstructions(
 
   return instructions
     .filter((i: any) => {
-      return Boolean(i.parsed.info.lamports) && i.parsed.type === "transfer";
+      return Boolean(i?.parsed?.info.lamports) && i.parsed.type === "transfer";
     })
     .map<Transfer>((i: any) => {
       const { info } = i.parsed;


### PR DESCRIPTION
metaplex AuctionHouse program change breaks the inner instruction filter because the `parsed` object doesn't exist